### PR TITLE
Rename symbols for metadata-extractor 2.7.2

### DIFF
--- a/tim/prune/jpeg/ExternalExifLibrary.java
+++ b/tim/prune/jpeg/ExternalExifLibrary.java
@@ -36,41 +36,41 @@ public class ExternalExifLibrary implements ExifLibrary
 			if (metadata.containsDirectory(GpsDirectory.class))
 			{
 				Directory gpsdir = metadata.getDirectory(GpsDirectory.class);
-				if (gpsdir.containsTag(GpsDirectory.TAG_GPS_LATITUDE)
-					&& gpsdir.containsTag(GpsDirectory.TAG_GPS_LONGITUDE)
-					&& gpsdir.containsTag(GpsDirectory.TAG_GPS_LATITUDE_REF)
-					&& gpsdir.containsTag(GpsDirectory.TAG_GPS_LONGITUDE_REF))
+				if (gpsdir.containsTag(GpsDirectory.TAG_LATITUDE)
+					&& gpsdir.containsTag(GpsDirectory.TAG_LONGITUDE)
+					&& gpsdir.containsTag(GpsDirectory.TAG_LATITUDE_REF)
+					&& gpsdir.containsTag(GpsDirectory.TAG_LONGITUDE_REF))
 				{
-					data.setLatitudeRef(gpsdir.getString(GpsDirectory.TAG_GPS_LATITUDE_REF));
-					Rational[] latRats = gpsdir.getRationalArray(GpsDirectory.TAG_GPS_LATITUDE);
+					data.setLatitudeRef(gpsdir.getString(GpsDirectory.TAG_LATITUDE_REF));
+					Rational[] latRats = gpsdir.getRationalArray(GpsDirectory.TAG_LATITUDE);
 					double seconds = ExifGateway.convertToPositiveValue(latRats[2].getNumerator(), latRats[2].getDenominator());
 					data.setLatitude(new double[] {latRats[0].doubleValue(),
 						latRats[1].doubleValue(), seconds});
-					data.setLongitudeRef(gpsdir.getString(GpsDirectory.TAG_GPS_LONGITUDE_REF));
-					Rational[] lonRats = gpsdir.getRationalArray(GpsDirectory.TAG_GPS_LONGITUDE);
+					data.setLongitudeRef(gpsdir.getString(GpsDirectory.TAG_LONGITUDE_REF));
+					Rational[] lonRats = gpsdir.getRationalArray(GpsDirectory.TAG_LONGITUDE);
 					seconds = ExifGateway.convertToPositiveValue(lonRats[2].getNumerator(), lonRats[2].getDenominator());
 					data.setLongitude(new double[] {lonRats[0].doubleValue(),
 						lonRats[1].doubleValue(), seconds});
 				}
 
 				// Altitude (if present)
-				if (gpsdir.containsTag(GpsDirectory.TAG_GPS_ALTITUDE) && gpsdir.containsTag(GpsDirectory.TAG_GPS_ALTITUDE_REF))
+				if (gpsdir.containsTag(GpsDirectory.TAG_ALTITUDE) && gpsdir.containsTag(GpsDirectory.TAG_ALTITUDE_REF))
 				{
-					data.setAltitude(gpsdir.getRational(GpsDirectory.TAG_GPS_ALTITUDE).intValue());
-					byte altRef = (byte) gpsdir.getInt(GpsDirectory.TAG_GPS_ALTITUDE_REF);
+					data.setAltitude(gpsdir.getRational(GpsDirectory.TAG_ALTITUDE).intValue());
+					byte altRef = (byte) gpsdir.getInt(GpsDirectory.TAG_ALTITUDE_REF);
 					data.setAltitudeRef(altRef);
 				}
 
 				try
 				{
 					// Timestamp and datestamp (if present)
-					final int TAG_GPS_DATESTAMP = 0x001d;
-					if (gpsdir.containsTag(GpsDirectory.TAG_GPS_TIME_STAMP) && gpsdir.containsTag(TAG_GPS_DATESTAMP))
+					final int TAG_DATE_STAMP = 0x001d;
+					if (gpsdir.containsTag(GpsDirectory.TAG_TIME_STAMP) && gpsdir.containsTag(TAG_DATE_STAMP))
 					{
-						Rational[] times = gpsdir.getRationalArray(GpsDirectory.TAG_GPS_TIME_STAMP);
+						Rational[] times = gpsdir.getRationalArray(GpsDirectory.TAG_TIME_STAMP);
 						data.setGpsTimestamp(new int[] {times[0].intValue(), times[1].intValue(),
 							times[2].intValue()});
-						Rational[] dates = gpsdir.getRationalArray(TAG_GPS_DATESTAMP);
+						Rational[] dates = gpsdir.getRationalArray(TAG_DATE_STAMP);
 						if (dates != null) {
 							data.setGpsDatestamp(new int[] {dates[0].intValue(), dates[1].intValue(), dates[2].intValue()});
 						}
@@ -79,9 +79,9 @@ public class ExternalExifLibrary implements ExifLibrary
 				catch (MetadataException me) {} // ignore, use other tags instead
 
 				// Image bearing (if present)
-				if (gpsdir.containsTag(GpsDirectory.TAG_GPS_IMG_DIRECTION) && gpsdir.containsTag(GpsDirectory.TAG_GPS_IMG_DIRECTION_REF))
+				if (gpsdir.containsTag(GpsDirectory.TAG_IMG_DIRECTION) && gpsdir.containsTag(GpsDirectory.TAG_IMG_DIRECTION_REF))
 				{
-					Rational bearing = gpsdir.getRational(GpsDirectory.TAG_GPS_IMG_DIRECTION);
+					Rational bearing = gpsdir.getRational(GpsDirectory.TAG_IMG_DIRECTION);
 					if (bearing != null) {
 						data.setBearing(bearing.doubleValue());
 					}


### PR DESCRIPTION
The 'GPS_' prefix was dropped after version 2.6.

JOSM will require metadata-extractor 2.7.2 with its next release, so we've updated the libmetadata-extractor-java package in Debian to 2.7.2.

To keep the gpsprune package working with the updated metadata-extractor this patch is included in the Debian package.