### PR TITLE
myTracks time format support

### DIFF
--- a/src/tim/prune/data/TimestampUtc.java
+++ b/src/tim/prune/data/TimestampUtc.java
@@ -25,7 +25,7 @@ public class TimestampUtc extends Timestamp
 	private static DateFormat[] ALL_DATE_FORMATS = null;
 	private static Calendar CALENDAR = null;
 	private static final Pattern ISO8601_FRACTIONAL_PATTERN
-		= Pattern.compile("(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})(?:[\\.,](\\d{1,3}))?(Z|[\\+-]\\d{2}(?::?\\d{2})?)?");
+		= Pattern.compile("(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})(?:[\\.,](\\d{1,5}))?(Z|[\\+-]\\d{2}(?::?\\d{2})?)?");
 		//                    year     month     day T  hour    minute    sec             millisec   Z or +/-  hours  :   minutes
 	private static final Pattern GENERAL_TIMESTAMP_PATTERN
 		= Pattern.compile("(\\d{4})\\D(\\d{2})\\D(\\d{2})\\D(\\d{2})\\D(\\d{2})\\D(\\d{2})");

--- a/src/tim/prune/data/TimestampUtc.java
+++ b/src/tim/prune/data/TimestampUtc.java
@@ -25,7 +25,7 @@ public class TimestampUtc extends Timestamp
 	private static DateFormat[] ALL_DATE_FORMATS = null;
 	private static Calendar CALENDAR = null;
 	private static final Pattern ISO8601_FRACTIONAL_PATTERN
-		= Pattern.compile("(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})(?:[\\.,](\\d{1,5}))?(Z|[\\+-]\\d{2}(?::?\\d{2})?)?");
+		= Pattern.compile("(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})(?:[.,](\\d{1,5}))?(Z|[+-]\\d{2}(?::?\\d{2})?)?");
 		//                    year     month     day T  hour    minute    sec             millisec   Z or +/-  hours  :   minutes
 	private static final Pattern GENERAL_TIMESTAMP_PATTERN
 		= Pattern.compile("(\\d{4})\\D(\\d{2})\\D(\\d{2})\\D(\\d{2})\\D(\\d{2})\\D(\\d{2})");

--- a/test/tim/prune/data/RecentFileListTest.java
+++ b/test/tim/prune/data/RecentFileListTest.java
@@ -1,9 +1,9 @@
 package tim.prune.data;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;

--- a/test/tim/prune/data/RecentFileTest.java
+++ b/test/tim/prune/data/RecentFileTest.java
@@ -1,8 +1,8 @@
 package tim.prune.data;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.File;
 import java.io.IOException;

--- a/test/tim/prune/data/TimestampTest.java
+++ b/test/tim/prune/data/TimestampTest.java
@@ -2,6 +2,7 @@ package tim.prune.data;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.Instant;
 import java.util.TimeZone;
 
 import org.junit.jupiter.api.Test;
@@ -41,5 +42,15 @@ class TimestampTest
 		assertEquals(earlier.getMillisecondsSince(later), -2000L);
 		assertFalse(earlier.isAfter(later));
 		assertTrue(earlier.isBefore(later));
+	}
+
+	@Test
+	void testMyTracksFormat() {
+		// myTracks by Dirk Stichling produces GPX files with timestamps of the form "2023-07-21T01:06:50.90200Z"
+		// http://www.mytracks4mac.info
+		TimestampUtc validDate = new TimestampUtc("2023-07-21T01:06:50.90200Z");
+		Instant instant = Instant.ofEpochMilli(1689901610000L);
+		assertTrue(validDate.isValid());
+		assertEquals(instant.toEpochMilli(), validDate.getMilliseconds(TimeZone.getTimeZone("GMT")));
 	}
 }


### PR DESCRIPTION
Hi,

The [myTracks ](https://www.mytracks4mac.info) IOS app produces slightly odd timestamps of the form
`2023-07-21T01:25:38.95100Z`
note the 5 digits of fractional time before the timezone...  Full except of a tkpt below if you're interested.

This PR modifies the regex, adds a unit test as well as some (very) minor tidy-ups.

I'm very happy to change this to suit another approach if you prefer (for example I suspect fractional should support up to microseconds rather than this odd halfway between millis and mics).

trkpt from myTracks
`<trkpt lat="7.226303854543608" lon="79.8397121879995"><ele>7.875593766513052</ele><time>2023-07-21T01:25:38.95100Z</time><extensions><mytracks:speed>0.05727850071516458</mytracks:speed><mytracks:length>0.01794754256126502</mytracks:length></extensions></trkpt>`

Thanks for the very useful tool.

(as an aside, I've now shifted to using the "GPX Tracker" IOS app but this PR allows me to tidy-up existing myTracks gpx files)

Cheers,
Rob