### PR TITLE
Fix tests

### DIFF
--- a/buildtools/build.gradle.kts
+++ b/buildtools/build.gradle.kts
@@ -24,8 +24,10 @@ java {
         java.srcDir("test")
         resources.srcDirs("test")
         resources.include(
-            "tim/prune/function/weather/xml/*"
+            "tim/prune/function/weather/xml/*",
+            "tim/prune/function/filesleuth/data/*.txt"
         )
+        output.setResourcesDir(layout.buildDirectory.dir("classes/java/test"))
     }
 }
 

--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -79,7 +79,9 @@
 				<directory>${project.basedir}/test</directory>
 				<includes>
 					<include>tim/prune/function/weather/xml/*</include>
+					<include>tim/prune/function/filesleuth/data/*.txt</include>
 				</includes>
+				<targetPath>${project.build.directory}/classes/java/test</targetPath>
 			</testResource>
 		</testResources>
 

--- a/test/tim/prune/function/srtm/InterpolatorTest.java
+++ b/test/tim/prune/function/srtm/InterpolatorTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+
 class InterpolatorTest extends Interpolator
 {
 	void testAverageNonVoid(int[] inInputs, double inExpected)
@@ -129,7 +131,7 @@ class InterpolatorTest extends Interpolator
 		for (int i=0; i<100; i++)
 		{
 			double height = Interpolator.calculateAltitude(11.2, 58.0 + i/100.0, altitudes, true, 7);
-			builder.append(String.format("%.3f", height));
+			builder.append(String.format(Locale.US, "%.3f", height));
 			builder.append(',');
 		}
 		String result = builder.toString();


### PR DESCRIPTION
I got some failing unit tests:

1. Gradle and Maven build scripts had to be changed in order for the newly added tests to work, introduced in 48f2bf1d800333616d2cb74c40d6399ad3b8b4a2.
2. I'm on a different system environment, with a locale where the decimal separator is not `.` but `,`. This lead to one test failing, where numbers where compared as String representation. By forcing `Locale.US`, this could be easily fixed.

Thank you for your great work on the project!